### PR TITLE
correct Opponent wins when Eris moves them (Pan & Eros)

### DIFF
--- a/modules/powers/Eros.class.php
+++ b/modules/powers/Eros.class.php
@@ -48,19 +48,26 @@ class Eros extends SantoriniPower
     $this->argPlayerPlaceWorker($arg);
   }
 
-  public function checkPlayerWinning(&$arg)
+  public function checkWinning(&$arg)
   {
     if ($arg['win']) {
       return;
     }
 
     $move = $this->game->log->getLastWork();
-    $workers = $this->game->board->getPlacedActiveWorkers();
+    $workers = $this->game->board->getPlacedWorkers($this->playerId);
 
     // Last work should be a move and Eros must have two workers left
     if ($move == null || $move['action'] != 'move' || count($workers) != 2) {
       return;
     }
+    
+    // win if Eris moved this worker but not Dionysus
+    $piece = $this->game->board->getPiece($move['pieceId']);
+    if ($this->game->log->isAdditionalTurn(DIONYSUS))
+    	return;
+    if ($piece['player_id'] != $this->playerId)
+    	return;
 
     // The two workers must be adjacent and on same level
     if (!$this->game->board->isNeighbour($workers[0], $workers[1], 'move') || $workers[0]['z'] !=  $workers[1]['z']) {
@@ -75,6 +82,7 @@ class Eros extends SantoriniPower
     // Eros wins
     $arg['win'] = true;
     $arg['winStats'] = [[$this->playerId, 'usePower']];
+    $arg['pId'] = $this->playerId;
     $msg = clienttranslate('${power_name}: ${player_name} has neighboring workers on ${level_name}');
     $this->game->notifyAllPlayers('message', $msg, [
       'i18n' => ['power_name'],
@@ -83,4 +91,18 @@ class Eros extends SantoriniPower
       'level_name' => $this->game->levelNames[intval($workers[0]['z'])],
     ]);
   }
+  
+  
+  
+  public function checkPlayerWinning(&$arg)
+  {
+  	$this->checkWinning($arg);
+  }
+  public function checkOpponentWinning(&$arg)
+  {
+  	$this->checkWinning($arg);
+  }  
+  
+  
+  
 }

--- a/modules/powers/Eros.class.php
+++ b/modules/powers/Eros.class.php
@@ -61,13 +61,12 @@ class Eros extends SantoriniPower
     if ($move == null || $move['action'] != 'move' || count($workers) != 2) {
       return;
     }
-    
-    // win if Eris moved this worker but not Dionysus
+
+    // Eros wins during opponent turn if Eris moved this worker (but not Dionysus)
     $piece = $this->game->board->getPiece($move['pieceId']);
-    if ($this->game->log->isAdditionalTurn(DIONYSUS))
-    	return;
-    if ($piece['player_id'] != $this->playerId)
-    	return;
+    if ($piece['player_id'] != $this->playerId || $this->game->log->isAdditionalTurn(DIONYSUS)) {
+      return;
+    }
 
     // The two workers must be adjacent and on same level
     if (!$this->game->board->isNeighbour($workers[0], $workers[1], 'move') || $workers[0]['z'] !=  $workers[1]['z']) {
@@ -91,18 +90,13 @@ class Eros extends SantoriniPower
       'level_name' => $this->game->levelNames[intval($workers[0]['z'])],
     ]);
   }
-  
-  
-  
+
   public function checkPlayerWinning(&$arg)
   {
-  	$this->checkWinning($arg);
+    $this->checkWinning($arg);
   }
   public function checkOpponentWinning(&$arg)
   {
-  	$this->checkWinning($arg);
-  }  
-  
-  
-  
+    $this->checkWinning($arg);
+  }
 }

--- a/modules/powers/Pan.class.php
+++ b/modules/powers/Pan.class.php
@@ -20,24 +20,46 @@ class Pan extends SantoriniPower
 
   /* * */
 
-  public function checkPlayerWinning(&$arg)
+  public function checkWinning(&$arg)
   {
     if ($arg['win']) {
       return;
     }
 
     $move = $this->game->log->getLastWork();
+    
+    	
     if ($move == null || $move['action'] != 'move' || $move['to']['z'] > $move['from']['z'] - 2) {
       return;
     }
 
+    // win if Eris moved this worker but not Dionysus
+    $piece = $this->game->board->getPiece($move['pieceId']);
+    if ($this->game->log->isAdditionalTurn(DIONYSUS))
+    	return;
+    if ($piece['player_id'] != $this->playerId)
+    	return;
+    
     // Pan wins
     $arg['win'] = true;
     $arg['winStats'] = [[$this->playerId, 'usePower']];
+    $arg['pId'] = $this->playerId;
     $this->game->notifyAllPlayers('message', clienttranslate('${power_name}: ${player_name} moved down two or more levels'), [
       'i18n' => ['power_name'],
       'power_name' => $this->getName(),
       'player_name' => $this->getPlayer()->getName(),
     ]);
   }
+  
+  
+  public function checkPlayerWinning(&$arg)
+  {
+  	$this->checkWinning($arg);
+  }
+  public function checkOpponentWinning(&$arg)
+  {
+  	$this->checkWinning($arg);
+  }  
 }
+
+

--- a/modules/powers/Pan.class.php
+++ b/modules/powers/Pan.class.php
@@ -27,19 +27,16 @@ class Pan extends SantoriniPower
     }
 
     $move = $this->game->log->getLastWork();
-    
-    	
     if ($move == null || $move['action'] != 'move' || $move['to']['z'] > $move['from']['z'] - 2) {
       return;
     }
 
-    // win if Eris moved this worker but not Dionysus
+    // Pan wins during opponent turn if Eris moved this worker (but not Dionysus)
     $piece = $this->game->board->getPiece($move['pieceId']);
-    if ($this->game->log->isAdditionalTurn(DIONYSUS))
-    	return;
-    if ($piece['player_id'] != $this->playerId)
-    	return;
-    
+    if ($piece['player_id'] != $this->playerId || $this->game->log->isAdditionalTurn(DIONYSUS)) {
+      return;
+    }
+
     // Pan wins
     $arg['win'] = true;
     $arg['winStats'] = [[$this->playerId, 'usePower']];
@@ -50,16 +47,14 @@ class Pan extends SantoriniPower
       'player_name' => $this->getPlayer()->getName(),
     ]);
   }
-  
-  
+
   public function checkPlayerWinning(&$arg)
   {
-  	$this->checkWinning($arg);
+    $this->checkWinning($arg);
   }
+
   public function checkOpponentWinning(&$arg)
   {
-  	$this->checkWinning($arg);
-  }  
+    $this->checkWinning($arg);
+  }
 }
-
-


### PR DESCRIPTION
Eris should trigger a win when moving Pan or Eros and fulfilling their winning condition